### PR TITLE
参数：远程配置和本地 application.properties 的优先级

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/properties/NacosConfigProperties.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/properties/NacosConfigProperties.java
@@ -70,6 +70,8 @@ public class NacosConfigProperties {
 
 	private boolean enableRemoteSyncConfig = false;
 
+	private boolean remoteFirst = false;
+
 	@JSONField(serialize = false)
 	private List<Config> extConfig = new ArrayList<>();
 
@@ -211,6 +213,14 @@ public class NacosConfigProperties {
 
 	public void setEnableRemoteSyncConfig(boolean enableRemoteSyncConfig) {
 		this.enableRemoteSyncConfig = enableRemoteSyncConfig;
+	}
+
+	public boolean isRemoteFirst() {
+		return remoteFirst;
+	}
+
+	public void setRemoteFirst(boolean remoteFirst) {
+		this.remoteFirst = remoteFirst;
 	}
 
 	public List<Config> getExtConfig() {

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigUtils.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigUtils.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Properties;
 import java.util.function.Function;
 
@@ -68,8 +69,15 @@ public class NacosConfigUtils {
                     globalProperties, config.getType());
             sources.addAll(elements);
         }
-        for (NacosPropertySource propertySource : sources) {
-            mutablePropertySources.addLast(propertySource);
+
+        if (nacosConfigProperties.isRemoteFirst()) {
+            for (ListIterator<NacosPropertySource> itr = sources.listIterator(sources.size()); itr.hasPrevious();) {
+                mutablePropertySources.addFirst(itr.previous());
+            }
+        } else {
+            for (NacosPropertySource propertySource : sources) {
+                mutablePropertySources.addLast(propertySource);
+            }
         }
     }
 


### PR DESCRIPTION
通过配置 nacos.config.remote-first=true, 使远程配置优先级高于本地 application.properties