### PR TITLE
fix #159 NoClassDefFoundError since springboot 2.3.0.M1

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/binder/NacosBootConfigurationPropertiesBinder.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/binder/NacosBootConfigurationPropertiesBinder.java
@@ -16,67 +16,81 @@
  */
 package com.alibaba.boot.nacos.config.binder;
 
-import java.lang.reflect.Method;
-
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.annotation.NacosConfigurationProperties;
 import com.alibaba.nacos.spring.context.properties.config.NacosConfigurationPropertiesBinder;
 import com.alibaba.nacos.spring.core.env.NacosPropertySource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.StandardEnvironment;
 
+import java.lang.reflect.Method;
+
 /**
  * @author <a href="mailto:liaochunyhm@live.com">liaochuntao</a>
  * @since 0.2.2
  */
 public class NacosBootConfigurationPropertiesBinder
-		extends NacosConfigurationPropertiesBinder {
+        extends NacosConfigurationPropertiesBinder {
 
-	private final Logger logger = LoggerFactory
-			.getLogger(NacosBootConfigurationPropertiesBinder.class);
+    private static final String LEGACY_BEAN_FACTORY_METADATA_CLZ = "org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata";
 
-	private ConfigurationBeanFactoryMetadata beanFactoryMetadata;
-	private StandardEnvironment environment = new StandardEnvironment();
+    private final Logger logger = LoggerFactory
+            .getLogger(NacosBootConfigurationPropertiesBinder.class);
 
-	public NacosBootConfigurationPropertiesBinder(
-			ConfigurableApplicationContext applicationContext) {
-		super(applicationContext);
-		this.beanFactoryMetadata = applicationContext.getBean(
-				ConfigurationBeanFactoryMetadata.BEAN_NAME,
-				ConfigurationBeanFactoryMetadata.class);
-	}
+    private Object beanFactoryMetadata;
+    private StandardEnvironment environment = new StandardEnvironment();
 
-	@Override
-	protected void doBind(Object bean, String beanName, String dataId, String groupId,
-			String configType, NacosConfigurationProperties properties, String content,
-			ConfigService configService) {
-		String name = "nacos-bootstrap-" + beanName;
-		NacosPropertySource propertySource = new NacosPropertySource(name, dataId,
-				groupId, content, configType);
-		environment.getPropertySources().addLast(propertySource);
-		Binder binder = Binder.get(environment);
-		ResolvableType type = getBeanType(bean, beanName);
-		Bindable<?> target = Bindable.of(type).withExistingValue(bean);
-		binder.bind(properties.prefix(), target);
-		publishBoundEvent(bean, beanName, dataId, groupId, properties, content,
-				configService);
-		publishMetadataEvent(bean, beanName, dataId, groupId, properties);
-		environment.getPropertySources().remove(name);
-	}
+    public NacosBootConfigurationPropertiesBinder(
+            ConfigurableApplicationContext applicationContext) {
+        super(applicationContext);
+        try {
+            Class<?> clz = Class.forName(LEGACY_BEAN_FACTORY_METADATA_CLZ);
+            this.beanFactoryMetadata = applicationContext.getBean(clz.getName(), clz);
+        } catch (ClassNotFoundException e) {
+            logger.warn("ConfigurationBeanFactoryMetadata not found, NacosConfigurationProperties with FactoryBean may not take effect.");
+        }
 
-	private ResolvableType getBeanType(Object bean, String beanName) {
-		Method factoryMethod = this.beanFactoryMetadata.findFactoryMethod(beanName);
-		if (factoryMethod != null) {
-			return ResolvableType.forMethodReturnType(factoryMethod);
-		}
-		return ResolvableType.forClass(bean.getClass());
-	}
+    }
+
+    @Override
+    protected void doBind(Object bean, String beanName, String dataId, String groupId,
+                          String configType, NacosConfigurationProperties properties, String content,
+                          ConfigService configService) {
+        String name = "nacos-bootstrap-" + beanName;
+        NacosPropertySource propertySource = new NacosPropertySource(name, dataId,
+                groupId, content, configType);
+        environment.getPropertySources().addLast(propertySource);
+        Binder binder = Binder.get(environment);
+        ResolvableType type = getBeanType(bean, beanName);
+        Bindable<?> target = Bindable.of(type).withExistingValue(bean);
+        binder.bind(properties.prefix(), target);
+        publishBoundEvent(bean, beanName, dataId, groupId, properties, content,
+                configService);
+        publishMetadataEvent(bean, beanName, dataId, groupId, properties);
+        environment.getPropertySources().remove(name);
+    }
+
+    private ResolvableType getBeanType(Object bean, String beanName) {
+        // Since 2.3.0.M1, ConfigurationBeanFactoryMetadata class has been removed, will cause exception if try find factory method
+        // Refer: https://github.com/spring-cloud/spring-cloud-config/issues/1543
+        if (beanFactoryMetadata == null) {
+            return ResolvableType.forClass(bean.getClass());
+        }
+        try {
+            Method findFactoryMethod = Class.forName(LEGACY_BEAN_FACTORY_METADATA_CLZ).getMethod("findFactoryMethod", String.class);
+            Method factoryMethod = (Method) findFactoryMethod.invoke(beanFactoryMetadata, beanName);
+            if (factoryMethod != null) {
+                return ResolvableType.forMethodReturnType(factoryMethod);
+            }
+        } catch (Exception ex) {
+            logger.warn("can not find factoryMethod while handling NacosConfigurationProperties: {}", ex.getMessage());
+        }
+        return ResolvableType.forClass(bean.getClass());
+    }
 
 }


### PR DESCRIPTION
Since SpringBoot 2.3.0.M1 there is no ConfigurationBeanFactoryMetadata class, causing NoClassDefFoundError  in SpringBoot 2.3.X, 2.4.X 
Refer: #159 

I fixed this and test well locally, my fix is compatible with previous version, and will not cause compile errors if dependency of SpringBoot 2.0.3.RELEASE upgraded.

### How did I fix this issue

1. Judge if ConfigurationBeanFactoryMetadata class exists, if not, beanFactoryMetadata will be null

```java
Class.forName(LEGACY_BEAN_FACTORY_METADATA_CLZ);
```

2. When it comes to doBind and getBeanType
  - if beanFactoryMetadata is null because of higher SpringBoot version, fallback to return bean type directly
  - if beanFactoryMetadata is not null, using the previous logic (but in reflect way)

```java
if (beanFactoryMetadata == null) {
    return ResolvableType.forClass(bean.getClass());
}
try {
    Method findFactoryMethod = Class.forName(LEGACY_BEAN_FACTORY_METADATA_CLZ).getMethod("findFactoryMethod", String.class);
    Method factoryMethod = (Method) findFactoryMethod.invoke(beanFactoryMetadata, beanName);
} 
......
```

### What's the potential risks

beanFactoryMetadata is used to judge return type when using FactoryBean, it may cause issues, BUT, maybe no one will use @NacosConfigurationProperties in this particular way like following:

```java
class SomeFactory implements FactoryBean<TypeA> {
    @Override
    public TypeA getObject() {
        // DO NOT USE THIS 'FactoryBean' WAY!
        return new TypeB();
    }
    ......
}

@NacosConfigurationProperties(dataId="xxx")
class TypeB extends TypeA {
}
```


