### PR TITLE
[ISSUE#215]fix bug（When a key is deleted from the map attribute of the configuration center, it is not actually deleted in the business system）

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/binder/NacosBootConfigurationPropertiesBinder.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/binder/NacosBootConfigurationPropertiesBinder.java
@@ -22,6 +22,7 @@ import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.config.annotation.NacosConfigurationProperties;
 import com.alibaba.nacos.spring.context.properties.config.NacosConfigurationPropertiesBinder;
 import com.alibaba.nacos.spring.core.env.NacosPropertySource;
+import com.alibaba.nacos.spring.util.ObjectUtils;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -56,6 +57,7 @@ public class NacosBootConfigurationPropertiesBinder
 			String name = "nacos-bootstrap-" + beanName;
 			NacosPropertySource propertySource = new NacosPropertySource(name, dataId, groupId, content, configType);
 			environment.getPropertySources().addLast(propertySource);
+			ObjectUtils.cleanMapOrCollectionField(bean);
 			Binder binder = Binder.get(environment);
 			ResolvableType type = getBeanType(bean, beanName);
 			Bindable<?> target = Bindable.of(type).withExistingValue(bean);


### PR DESCRIPTION
When a key is deleted from the map attribute of the configuration center, it is not actually deleted in the business system（#215）
配置中心map属性删除某个key时，业务系统中实际并没有被删除 for#215