### PR TITLE
[ISSUE#242]modify log overload method

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigEnvironmentProcessor.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigEnvironmentProcessor.java
@@ -83,12 +83,12 @@ public class NacosConfigEnvironmentProcessor
 		application.addInitializers(new NacosConfigApplicationContextInitializer(this));
 		nacosConfigProperties = NacosConfigPropertiesUtils
 				.buildNacosConfigProperties(environment);
-        NacosConfigLoader nacosConfigLoader = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties, environment, builder);
-        LogAutoFreshProcess.build(environment, nacosConfigProperties, nacosConfigLoader, builder).process();
 		if (enable()) {
 			System.out.println(
 					"[Nacos Config Boot] : The preload log configuration is enabled");
 			loadConfig(environment);
+			NacosConfigLoader nacosConfigLoader = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties, environment, builder);
+			LogAutoFreshProcess.build(environment, nacosConfigProperties, nacosConfigLoader, builder).process();
 		}
 	}
 

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/logging/NacosLoggingListener.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/logging/NacosLoggingListener.java
@@ -17,6 +17,8 @@
 package com.alibaba.boot.nacos.config.logging;
 
 
+import com.alibaba.boot.nacos.config.properties.NacosConfigProperties;
+import com.alibaba.boot.nacos.config.util.NacosConfigPropertiesUtils;
 import com.alibaba.nacos.client.logging.NacosLogging;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.context.ApplicationEvent;
@@ -43,12 +45,18 @@ public class NacosLoggingListener implements GenericApplicationListener {
 	
 	@Override
 	public boolean supportsSourceType(Class<?> aClass) {
-		return false;
+		return true;
 	}
 	
 	@Override
 	public void onApplicationEvent(ApplicationEvent applicationEvent) {
-		NacosLogging.getInstance().loadConfiguration();
+		//If the managed log is enabled, load your own log configuration after loading the user log configuration
+		ApplicationEnvironmentPreparedEvent applicationEnvironmentPreparedEvent = (ApplicationEnvironmentPreparedEvent) applicationEvent;
+		NacosConfigProperties nacosConfigProperties = NacosConfigPropertiesUtils.buildNacosConfigProperties(
+				applicationEnvironmentPreparedEvent.getEnvironment());
+		if(nacosConfigProperties.getBootstrap().isLogEnable()){
+			NacosLogging.getInstance().loadConfiguration();
+		}
 	}
 
 	@Override

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/log/LogAutoFreshProcess.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/log/LogAutoFreshProcess.java
@@ -46,8 +46,8 @@ import java.util.function.Function;
 
 /**
  * Start:
- * Step 1: get the log XML configuration from the configuration center
- * Step 2: modify the springboot log configuration path
+ * Step1: get the log XML configuration from the configuration center
+ * Step2: modify the springboot log configuration path
  * Modifying log configuration during operation:
  * Clean up the configuration through LoggingSystem and reload the configuration.
  *

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/log/LogAutoFreshProcess.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/log/LogAutoFreshProcess.java
@@ -107,8 +107,8 @@ public class LogAutoFreshProcess {
                 @Override
                 public void receiveConfigInfo(String configInfo) {
                     if (StringUtils.isNotBlank(configInfo)) {
-                        File file = writeLogFile(configInfo, dataId);
-                        reloadConfig(file);
+                        writeLogFile(configInfo, dataId);
+                        reloadConfig(LOG_CACHE_BASE + File.separator + dataId);
                     }
                 }
             });
@@ -117,7 +117,7 @@ public class LogAutoFreshProcess {
         }
     }
 
-    private File writeLogFile(String content, String dataId) {
+    private void writeLogFile(String content, String dataId) {
         File file = new File(LOG_CACHE_BASE, dataId);
         File parentFile = file.getParentFile();
         if (!parentFile.exists()) {
@@ -135,15 +135,14 @@ public class LogAutoFreshProcess {
         } catch (IOException e) {
             throw new RuntimeException("write log file fail");
         }
-        return file;
     }
 
-    private void reloadConfig(File file) {
+    private void reloadConfig(String logPath) {
         LoggingSystem loggingSystem = LoggingSystemFactory.fromSpringFactories()
                 .getLoggingSystem(this.getClass().getClassLoader());
         loggingSystem.cleanUp();
         loggingSystem.initialize(new LoggingInitializationContext(environment),
-                file == null ? null : file.getAbsolutePath(), null);
+                logPath, null);
         NacosLogging.getInstance().loadConfiguration();
     }
 

--- a/nacos-discovery-spring-boot-actuator/src/test/resources/application.properties
+++ b/nacos-discovery-spring-boot-actuator/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+nacos.discovery.serverAddr = "127.0.0.1:8848"

--- a/nacos-spring-boot-parent/pom.xml
+++ b/nacos-spring-boot-parent/pom.xml
@@ -52,7 +52,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <nacos.version>2.0.4</nacos.version>
+        <nacos.version>2.1.0</nacos.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
for #242  #228
1.设置开关nacos.config.bootstrap.logEnable=true之后才能托管日志
2.调用springboot方法重载日志，不直接依赖日志框架
3.如果开启了托管日志，加载完用户日志配置之后在加载一次自己的日志配置
4.由于该功能依赖最新nacos-client 2.1.0对日志的相关改动，升级nacos-client 依赖

1.Set the switch Nacos config. bootstrap. Log cannot be managed until logenable = true
2.Call the springboot method to overload the log without directly relying on the log framework
3.If the managed log is enabled, load your own log configuration after loading the user log configuration
4. Because this function relies on the relevant changes of the latest Nacos client 2.1.0 to the log, upgrade the Nacos client dependency