### PR TITLE
完善配置中心配置项说明文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Nacos Spring Boot Project consist of two parts: `nacos-config-spring-boot` and `
 
 For more information about Nacos Spring, see [Nacos Spring Project](https://github.com/nacos-group/nacos-spring-project).
 
+## Configuration
+### config center
+|  item                | description                                                                                           |
+|-----------------------------------|-------------------------------------------------------------------------------------------------------|
+| nacos.config.bootstrap.enable     | load configuration on startup,optional values: true/false                                             |
+| nacos.config.bootstrap.log-enable | is the log level based on the configuration center,optional values: true/false                        |
+| nacos.config.remote-first         | prioritize using Nacos server configuration,optional values: true/false                               |
+| nacos.config.server-addr          | nacos server address                                                                                  |
+| nacos.config.data-ids             | set of configuration dataids that need to be monitored, multiple separated by commas                  |
+| nacos.config.namespace            | nacos namespace                                                                                       |
+| nacos.config.group                | nacos group                                                                                           |
+| nacos.config.username             | nacos username                                                                                        |
+| nacos.config.password             | nacos password                                                                                        |
+| nacos.config.type                 | type of configuration content,optional values: properties/yaml                                                                                             |
+| nacos.config.auto-refresh         | automatically refresh when the configuration of the nacos server changes ,optional values: true/false |
 ## Relative Projects
 
 * [Alibaba Nacos](https://github.com/alibaba/nacos)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more information about Nacos Spring, see [Nacos Spring Project](https://gith
 | nacos.config.remote-first         | prioritize using Nacos server configuration,optional values: true/false                               |
 | nacos.config.auto-refresh         | automatically refresh when the configuration of the nacos server changes ,optional values: true/false |
 | nacos.config.server-addr          | nacos server address                                                                                  |
-| nacos.config.data-ids             | set of configuration dataids that need to be monitored, multiple separated by commas                  |
+| nacos.config.data-ids             | configuration dataids that need to be monitored, multiple separated by commas                  |
 | nacos.config.namespace            | nacos namespace                                                                                       |
 | nacos.config.group                | nacos group                                                                                           |
 | nacos.config.username             | nacos username                                                                                        |

--- a/README.md
+++ b/README.md
@@ -61,14 +61,15 @@ For more information about Nacos Spring, see [Nacos Spring Project](https://gith
 | nacos.config.bootstrap.enable     | load configuration on startup,optional values: true/false                                             |
 | nacos.config.bootstrap.log-enable | is the log level based on the configuration center,optional values: true/false                        |
 | nacos.config.remote-first         | prioritize using Nacos server configuration,optional values: true/false                               |
+| nacos.config.auto-refresh         | automatically refresh when the configuration of the nacos server changes ,optional values: true/false |
 | nacos.config.server-addr          | nacos server address                                                                                  |
 | nacos.config.data-ids             | set of configuration dataids that need to be monitored, multiple separated by commas                  |
 | nacos.config.namespace            | nacos namespace                                                                                       |
 | nacos.config.group                | nacos group                                                                                           |
 | nacos.config.username             | nacos username                                                                                        |
 | nacos.config.password             | nacos password                                                                                        |
-| nacos.config.type                 | type of configuration content,optional values: properties/yaml                                                                                             |
-| nacos.config.auto-refresh         | automatically refresh when the configuration of the nacos server changes ,optional values: true/false |
+| nacos.config.type                 | type of configuration content,optional values: properties/yaml                                        |
+
 ## Relative Projects
 
 * [Alibaba Nacos](https://github.com/alibaba/nacos)


### PR DESCRIPTION
当前配置中心启动参数无说明，容易造成错用，如：#280