### PR TITLE
[ISSUE #293] Fixed yaml configuration not working

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
@@ -16,7 +16,6 @@
  */
 package com.alibaba.boot.nacos.config.autoconfigure;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.function.Function;
 

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
@@ -16,6 +16,7 @@
  */
 package com.alibaba.boot.nacos.config.autoconfigure;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.function.Function;
 
@@ -60,18 +61,18 @@ public class NacosConfigApplicationContextInitializer
 	private NacosConfigProperties nacosConfigProperties;
 
 	public NacosConfigApplicationContextInitializer(
-			NacosConfigEnvironmentProcessor configEnvironmentProcessor) {
+			NacosConfigEnvironmentProcessor configEnvironmentProcessor, NacosConfigProperties nacosConfigProperties) {
 		this.processor = configEnvironmentProcessor;
+		this.nacosConfigProperties = nacosConfigProperties;
 	}
 
 	@Override
 	public void initialize(ConfigurableApplicationContext context) {
 		singleton.setApplicationContext(context);
 		environment = context.getEnvironment();
-		nacosConfigProperties = NacosConfigPropertiesUtils
-				.buildNacosConfigProperties(environment);
+		NacosConfigPropertiesUtils.buildNacosConfigProperties(environment, nacosConfigProperties);
 		final NacosConfigLoader configLoader = NacosConfigLoaderFactory.getSingleton(
-				nacosConfigProperties, environment, builder);
+				nacosConfigProperties, builder);
 		if (!enable()) {
 			logger.info("[Nacos Config Boot] : The preload configuration is not enabled");
 		}
@@ -86,7 +87,7 @@ public class NacosConfigApplicationContextInitializer
 						.addListenerIfAutoRefreshed(processor.getDeferPropertySources());
 			}
 			else {
-				configLoader.loadConfig();
+				configLoader.loadConfig(environment);
 				configLoader.addListenerIfAutoRefreshed();
 			}
 		}

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
@@ -61,18 +61,16 @@ public class NacosConfigApplicationContextInitializer
 	private NacosConfigProperties nacosConfigProperties;
 
 	public NacosConfigApplicationContextInitializer(
-			NacosConfigEnvironmentProcessor configEnvironmentProcessor, NacosConfigProperties nacosConfigProperties) {
+			NacosConfigEnvironmentProcessor configEnvironmentProcessor) {
 		this.processor = configEnvironmentProcessor;
-		this.nacosConfigProperties = nacosConfigProperties;
 	}
 
 	@Override
 	public void initialize(ConfigurableApplicationContext context) {
 		singleton.setApplicationContext(context);
 		environment = context.getEnvironment();
-		NacosConfigPropertiesUtils.buildNacosConfigProperties(environment, nacosConfigProperties);
-		final NacosConfigLoader configLoader = NacosConfigLoaderFactory.getSingleton(
-				nacosConfigProperties, builder);
+		nacosConfigProperties = NacosConfigPropertiesUtils.buildNacosConfigProperties(environment);
+		final NacosConfigLoader configLoader = NacosConfigLoaderFactory.getSingleton(builder);
 		if (!enable()) {
 			logger.info("[Nacos Config Boot] : The preload configuration is not enabled");
 		}
@@ -87,7 +85,7 @@ public class NacosConfigApplicationContextInitializer
 						.addListenerIfAutoRefreshed(processor.getDeferPropertySources());
 			}
 			else {
-				configLoader.loadConfig(environment);
+				configLoader.loadConfig(environment, nacosConfigProperties);
 				configLoader.addListenerIfAutoRefreshed();
 			}
 		}

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigEnvironmentProcessor.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigEnvironmentProcessor.java
@@ -82,7 +82,8 @@ public class NacosConfigEnvironmentProcessor
 	public void postProcessEnvironment(ConfigurableEnvironment environment,
 			SpringApplication application) {
 		application.addInitializers(new NacosConfigApplicationContextInitializer(this));
-		nacosConfigProperties = NacosConfigPropertiesUtils.buildNacosConfigProperties(environment);
+		nacosConfigProperties = NacosConfigPropertiesUtils
+				.buildNacosConfigProperties(environment);
 		if (enable()) {
 			System.out.println(
 					"[Nacos Config Boot] : The preload log configuration is enabled");

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoader.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoader.java
@@ -48,23 +48,19 @@ public class NacosConfigLoader {
 
 	private final Logger logger = LoggerFactory.getLogger(NacosConfigLoader.class);
 
-	private final NacosConfigProperties nacosConfigProperties;
-
 	private Properties globalProperties = new Properties();
 
 	private final Function<Properties, ConfigService> builder;
 	private final List<DeferNacosPropertySource> nacosPropertySources = new LinkedList<>();
-	public NacosConfigLoader(NacosConfigProperties nacosConfigProperties,
-			Function<Properties, ConfigService> builder) {
-		this.nacosConfigProperties = nacosConfigProperties;
+
+	public NacosConfigLoader(Function<Properties, ConfigService> builder) {
 		this.builder = builder;
 	}
 
-	public void loadConfig(ConfigurableEnvironment environment) {
-		globalProperties = buildGlobalNacosProperties(environment);
+	public void loadConfig(ConfigurableEnvironment environment, NacosConfigProperties nacosConfigProperties) {
+		globalProperties = buildGlobalNacosProperties(environment, nacosConfigProperties);
 		MutablePropertySources mutablePropertySources = environment.getPropertySources();
-		List<NacosPropertySource> sources = reqGlobalNacosConfig(environment, globalProperties,
-				nacosConfigProperties.getType());
+		List<NacosPropertySource> sources = reqGlobalNacosConfig(environment, globalProperties, nacosConfigProperties);
 		for (NacosConfigProperties.Config config : nacosConfigProperties.getExtConfig()) {
 			List<NacosPropertySource> elements = reqSubNacosConfig(environment, config,
 					globalProperties, config.getType());
@@ -82,7 +78,7 @@ public class NacosConfigLoader {
 		}
 	}
 
-	public Properties buildGlobalNacosProperties(ConfigurableEnvironment environment) {
+	public Properties buildGlobalNacosProperties(ConfigurableEnvironment environment, NacosConfigProperties nacosConfigProperties) {
 		return NacosPropertiesBuilder.buildNacosProperties(environment,
 				nacosConfigProperties.getServerAddr(),
 				nacosConfigProperties.getNamespace(), nacosConfigProperties.getEndpoint(),
@@ -109,7 +105,7 @@ public class NacosConfigLoader {
 	}
 
 	private List<NacosPropertySource> reqGlobalNacosConfig(ConfigurableEnvironment environment, Properties globalProperties,
-			ConfigType type) {
+			NacosConfigProperties nacosConfigProperties) {
 		List<String> dataIds = new ArrayList<>();
 		// Loads all data-id information into the list in the list
 		if (!StringUtils.hasLength(nacosConfigProperties.getDataId())) {
@@ -126,7 +122,7 @@ public class NacosConfigLoader {
 				.resolvePlaceholders(nacosConfigProperties.getGroup());
 		final boolean isAutoRefresh = nacosConfigProperties.isAutoRefresh();
 		return new ArrayList<>(Arrays.asList(reqNacosConfig(environment, globalProperties,
-				dataIds.toArray(new String[0]), groupName, type, isAutoRefresh)));
+				dataIds.toArray(new String[0]), groupName, nacosConfigProperties.getType(), isAutoRefresh)));
 	}
 
 	private List<NacosPropertySource> reqSubNacosConfig(ConfigurableEnvironment environment,

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoaderFactory.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoaderFactory.java
@@ -31,12 +31,11 @@ public class NacosConfigLoaderFactory {
 
     private static volatile NacosConfigLoader nacosConfigLoader;
 
-    public static NacosConfigLoader getSingleton(NacosConfigProperties nacosConfigProperties,
-                                                 Function<Properties, ConfigService> builder) {
+    public static NacosConfigLoader getSingleton(Function<Properties, ConfigService> builder) {
         if (nacosConfigLoader == null) {
             synchronized (NacosConfigLoaderFactory.class) {
                 if (nacosConfigLoader == null) {
-                    nacosConfigLoader = new NacosConfigLoader(nacosConfigProperties, builder);
+                    nacosConfigLoader = new NacosConfigLoader(builder);
                 }
             }
         }

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoaderFactory.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoaderFactory.java
@@ -32,12 +32,11 @@ public class NacosConfigLoaderFactory {
     private static volatile NacosConfigLoader nacosConfigLoader;
 
     public static NacosConfigLoader getSingleton(NacosConfigProperties nacosConfigProperties,
-                                                 ConfigurableEnvironment environment,
                                                  Function<Properties, ConfigService> builder) {
         if (nacosConfigLoader == null) {
             synchronized (NacosConfigLoaderFactory.class) {
                 if (nacosConfigLoader == null) {
-                    nacosConfigLoader = new NacosConfigLoader(nacosConfigProperties, environment, builder);
+                    nacosConfigLoader = new NacosConfigLoader(nacosConfigProperties, builder);
                 }
             }
         }

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigPropertiesUtils.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigPropertiesUtils.java
@@ -18,6 +18,7 @@ package com.alibaba.boot.nacos.config.util;
 
 import com.alibaba.boot.nacos.config.NacosConfigConstants;
 import com.alibaba.boot.nacos.config.properties.NacosConfigProperties;
+import com.alibaba.nacos.api.config.ConfigService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +26,9 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.ConfigurableEnvironment;
+
+import java.util.Properties;
+import java.util.function.Function;
 
 /**
  * Springboot used to own property binding configured binding
@@ -37,9 +41,32 @@ public class NacosConfigPropertiesUtils {
 	private static final Logger logger = LoggerFactory
 			.getLogger(NacosConfigPropertiesUtils.class);
 
+	private static volatile NacosConfigProperties nacosConfigProperties;
+
+	public static NacosConfigProperties getSingleton() {
+		if (nacosConfigProperties == null) {
+			synchronized (NacosConfigLoaderFactory.class) {
+				if (nacosConfigProperties == null) {
+					nacosConfigProperties = new NacosConfigProperties();
+				}
+			}
+		}
+		return nacosConfigProperties;
+	}
+
 	public static NacosConfigProperties buildNacosConfigProperties(
 			ConfigurableEnvironment environment) {
 		NacosConfigProperties nacosConfigProperties = new NacosConfigProperties();
+		Binder binder = Binder.get(environment);
+		ResolvableType type = ResolvableType.forClass(NacosConfigProperties.class);
+		Bindable<?> target = Bindable.of(type).withExistingValue(nacosConfigProperties);
+		binder.bind(NacosConfigConstants.PREFIX, target);
+		logger.info("nacosConfigProperties : {}", nacosConfigProperties);
+		return nacosConfigProperties;
+	}
+
+	public static NacosConfigProperties buildNacosConfigProperties(
+			ConfigurableEnvironment environment, NacosConfigProperties nacosConfigProperties) {
 		Binder binder = Binder.get(environment);
 		ResolvableType type = ResolvableType.forClass(NacosConfigProperties.class);
 		Bindable<?> target = Bindable.of(type).withExistingValue(nacosConfigProperties);

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigPropertiesUtils.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigPropertiesUtils.java
@@ -41,32 +41,9 @@ public class NacosConfigPropertiesUtils {
 	private static final Logger logger = LoggerFactory
 			.getLogger(NacosConfigPropertiesUtils.class);
 
-	private static volatile NacosConfigProperties nacosConfigProperties;
-
-	public static NacosConfigProperties getSingleton() {
-		if (nacosConfigProperties == null) {
-			synchronized (NacosConfigLoaderFactory.class) {
-				if (nacosConfigProperties == null) {
-					nacosConfigProperties = new NacosConfigProperties();
-				}
-			}
-		}
-		return nacosConfigProperties;
-	}
-
 	public static NacosConfigProperties buildNacosConfigProperties(
 			ConfigurableEnvironment environment) {
 		NacosConfigProperties nacosConfigProperties = new NacosConfigProperties();
-		Binder binder = Binder.get(environment);
-		ResolvableType type = ResolvableType.forClass(NacosConfigProperties.class);
-		Bindable<?> target = Bindable.of(type).withExistingValue(nacosConfigProperties);
-		binder.bind(NacosConfigConstants.PREFIX, target);
-		logger.info("nacosConfigProperties : {}", nacosConfigProperties);
-		return nacosConfigProperties;
-	}
-
-	public static NacosConfigProperties buildNacosConfigProperties(
-			ConfigurableEnvironment environment, NacosConfigProperties nacosConfigProperties) {
 		Binder binder = Binder.get(environment);
 		ResolvableType type = ResolvableType.forClass(NacosConfigProperties.class);
 		Bindable<?> target = Bindable.of(type).withExistingValue(nacosConfigProperties);

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/autoconfigure/NacosConfigApplicationContextInitializerTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/autoconfigure/NacosConfigApplicationContextInitializerTest.java
@@ -60,7 +60,7 @@ public class NacosConfigApplicationContextInitializerTest {
     
     @Before
     public void testNacosConfigApplicationContextInitializer() {
-        nacosConfigApplicationContextInitializer = new NacosConfigApplicationContextInitializer(new NacosConfigEnvironmentProcessor(), new NacosConfigProperties());
+        nacosConfigApplicationContextInitializer = new NacosConfigApplicationContextInitializer(new NacosConfigEnvironmentProcessor());
     }
     
     @Test
@@ -69,11 +69,10 @@ public class NacosConfigApplicationContextInitializerTest {
             nacosConfigProperties = NacosConfigPropertiesUtils
                     .buildNacosConfigProperties(environment);
             Assert.assertNotNull(nacosConfigProperties);
-            NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties,
-                    null);
+            NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(null);
             Assert.assertNotNull(singleton);
             nacosConfigApplicationContextInitializer.initialize(context);
-        }catch (Exception e) {
+        } catch (Exception e) {
             Assert.assertNotNull(e);
         }
     }

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/autoconfigure/NacosConfigApplicationContextInitializerTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/autoconfigure/NacosConfigApplicationContextInitializerTest.java
@@ -60,7 +60,7 @@ public class NacosConfigApplicationContextInitializerTest {
     
     @Before
     public void testNacosConfigApplicationContextInitializer() {
-        nacosConfigApplicationContextInitializer = new NacosConfigApplicationContextInitializer(new NacosConfigEnvironmentProcessor());
+        nacosConfigApplicationContextInitializer = new NacosConfigApplicationContextInitializer(new NacosConfigEnvironmentProcessor(), new NacosConfigProperties());
     }
     
     @Test
@@ -69,7 +69,7 @@ public class NacosConfigApplicationContextInitializerTest {
             nacosConfigProperties = NacosConfigPropertiesUtils
                     .buildNacosConfigProperties(environment);
             Assert.assertNotNull(nacosConfigProperties);
-            NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties, environment,
+            NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties,
                     null);
             Assert.assertNotNull(singleton);
             nacosConfigApplicationContextInitializer.initialize(context);

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderFactoryTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderFactoryTest.java
@@ -29,9 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -81,10 +79,8 @@ public class NacosConfigLoaderFactoryTest {
     
     @Test
     public void getSingleton() {
-        NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties,
-                builder);
-        NacosConfigLoader singleton2 = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties,
-                builder);
+        NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(builder);
+        NacosConfigLoader singleton2 = NacosConfigLoaderFactory.getSingleton(builder);
         // Verify that it is the same object
         Assert.assertEquals(singleton2, singleton);
     }

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderFactoryTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderFactoryTest.java
@@ -54,9 +54,6 @@ public class NacosConfigLoaderFactoryTest {
     
     private Function<Properties, ConfigService> builder;
     
-    @Autowired
-    private ConfigurableEnvironment environment;
-    
     @Before
     public void setup() {
         nacosConfigProperties = new NacosConfigProperties();
@@ -84,9 +81,9 @@ public class NacosConfigLoaderFactoryTest {
     
     @Test
     public void getSingleton() {
-        NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties, environment,
+        NacosConfigLoader singleton = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties,
                 builder);
-        NacosConfigLoader singleton2 = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties, environment,
+        NacosConfigLoader singleton2 = NacosConfigLoaderFactory.getSingleton(nacosConfigProperties,
                 builder);
         // Verify that it is the same object
         Assert.assertEquals(singleton2, singleton);

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
@@ -56,7 +56,6 @@ public class NacosConfigLoaderTest {
     
     private NacosConfigLoader nacosConfigLoader;
     
-    
     private NacosConfigProperties nacosConfigProperties;
     
     private Properties globalProperties;
@@ -96,13 +95,13 @@ public class NacosConfigLoaderTest {
             }
         };
         nacosPropertySources = new LinkedList<>();
-        nacosConfigLoader = new NacosConfigLoader(nacosConfigProperties, builder);
+        nacosConfigLoader = new NacosConfigLoader(builder);
         nacosPropertySourcePostProcessor = new NacosPropertySourcePostProcessor();
     }
 
     @Test
     public void buildGlobalNacosProperties() {
-        Properties properties = nacosConfigLoader.buildGlobalNacosProperties(environment);
+        Properties properties = nacosConfigLoader.buildGlobalNacosProperties(environment, nacosConfigProperties);
         LOGGER.info("buildGlobalNacosProperties properties : {}", properties);
         Assert.assertNotNull(properties);
         Assert.assertEquals(properties.size(), 6);

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -96,13 +97,13 @@ public class NacosConfigLoaderTest {
             }
         };
         nacosPropertySources = new LinkedList<>();
-        nacosConfigLoader = new NacosConfigLoader(nacosConfigProperties, environment, builder);
+        nacosConfigLoader = new NacosConfigLoader(nacosConfigProperties, builder);
         nacosPropertySourcePostProcessor = new NacosPropertySourcePostProcessor();
     }
 
     @Test
     public void buildGlobalNacosProperties() {
-        Properties properties = nacosConfigLoader.buildGlobalNacosProperties();
+        Properties properties = nacosConfigLoader.buildGlobalNacosProperties(new StandardEnvironment());
         LOGGER.info("buildGlobalNacosProperties properties : {}", properties);
         Assert.assertNotNull(properties);
         Assert.assertEquals(properties.size(), 6);

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
@@ -103,7 +103,7 @@ public class NacosConfigLoaderTest {
 
     @Test
     public void buildGlobalNacosProperties() {
-        Properties properties = nacosConfigLoader.buildGlobalNacosProperties(new StandardEnvironment());
+        Properties properties = nacosConfigLoader.buildGlobalNacosProperties(environment);
         LOGGER.info("buildGlobalNacosProperties properties : {}", properties);
         Assert.assertNotNull(properties);
         Assert.assertEquals(properties.size(), 6);

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 


### PR DESCRIPTION
开启 nacos.config.bootstrap.enable=true。NacosConfigLoader 单例后会有问题。

第一次加载`AnnotationConfigApplicationContext`时，`nacosConfigProperties` 还是都是默认的，这个时候去找`NacosConfigLoader`，没有，就初始化了，并且单例了。

第二次加载`AnnotationConfigServletWebServerApplicationContext`时候，`nacosConfigProperties`已经从 yaml 中拿到了配置的值了，但是`NacosConfigLoader`在第一个加载的时候已经初始化了，内部的`NacosConfigProperties` 是默认的没办法修改了。导致后续的`configLoader.loadConfig()`取 `dataIds `的时候会为空，进行抛出异常.

或者说根据参数缓存一下NacosConfigLoader，而不是做一个单例。大佬们觉得怎么修复比较好呢？

不一致：
<img width="962" alt="image" src="https://github.com/nacos-group/nacos-spring-boot-project/assets/29777558/14fc4a09-8b54-4736-9cbe-83c8766f41c6">


抛出的异常：
`java.lang.IllegalArgumentException: 'value' must not be null
	at org.springframework.util.Assert.notNull(Assert.java:201) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.util.PropertyPlaceholderHelper.replacePlaceholders(PropertyPlaceholderHelper.java:125) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.core.env.AbstractPropertyResolver.doResolvePlaceholders(AbstractPropertyResolver.java:239) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.core.env.AbstractPropertyResolver.resolvePlaceholders(AbstractPropertyResolver.java:202) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at org.springframework.core.env.AbstractEnvironment.resolvePlaceholders(AbstractEnvironment.java:566) ~[spring-core-5.2.15.RELEASE.jar:5.2.15.RELEASE]
	at com.alibaba.boot.nacos.config.util.NacosConfigLoader.reqGlobalNacosConfig(NacosConfigLoader.java:120) ~[nacos-config-spring-boot-autoconfigure-0.2.12.jar:0.2.12]
	at com.alibaba.boot.nacos.config.util.NacosConfigLoader.loadConfig(NacosConfigLoader.java:69) ~[nacos-config-spring-boot-autoconfigure-0.2.12.jar:0.2.12]
	at com.alibaba.boot.nacos.config.autoconfigure.NacosConfigApplicationContextInitializer.initialize(NacosConfigApplicationContextInitializer.java:89) ~[nacos-config-spring-boot-autoconfigure-0.2.12.jar:0.2.12]
	at org.springframework.boot.SpringApplication.applyInitializers(SpringApplication.java:623) [spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplication.prepareContext(SpringApplication.java:367) [spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:311) [spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1247) [spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1236) [spring-boot-2.3.12.RELEASE.jar:2.3.12.RELEASE]`