### PR TITLE
增加 nacos.config.bootstrap.snapshot-enable 配置，用于关闭，开启是否保存快照

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
@@ -25,6 +25,7 @@ import com.alibaba.boot.nacos.config.util.NacosConfigLoaderFactory;
 import com.alibaba.boot.nacos.config.util.NacosConfigPropertiesUtils;
 import com.alibaba.nacos.api.config.ConfigService;
 import com.alibaba.nacos.api.exception.NacosException;
+import com.alibaba.nacos.client.config.utils.SnapShotSwitch;
 import com.alibaba.nacos.spring.factory.CacheableEventPublishingNacosServiceFactory;
 import com.alibaba.nacos.spring.util.NacosBeanUtils;
 import org.slf4j.Logger;
@@ -72,6 +73,11 @@ public class NacosConfigApplicationContextInitializer
 				.buildNacosConfigProperties(environment);
 		final NacosConfigLoader configLoader = NacosConfigLoaderFactory.getSingleton(
 				nacosConfigProperties, environment, builder);
+
+		if (!processor.snapshotEnable()){
+			SnapShotSwitch.setIsSnapShot(false);
+		}
+
 		if (!enable()) {
 			logger.info("[Nacos Config Boot] : The preload configuration is not enabled");
 		}

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigEnvironmentProcessor.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigEnvironmentProcessor.java
@@ -105,6 +105,11 @@ public class NacosConfigEnvironmentProcessor
 				&& nacosConfigProperties.getBootstrap().isLogEnable();
 	}
 
+	boolean snapshotEnable() {
+		return nacosConfigProperties != null
+				&& nacosConfigProperties.getBootstrap().isSnapshotEnable();
+	}
+
 	LinkedList<NacosConfigLoader.DeferNacosPropertySource> getDeferPropertySources() {
 		return deferPropertySources;
 	}

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/properties/NacosConfigProperties.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/properties/NacosConfigProperties.java
@@ -292,6 +292,8 @@ public class NacosConfigProperties {
 
 		private boolean logEnable;
 
+		private boolean snapshotEnable;
+
 		public boolean isEnable() {
 			return enable;
 		}
@@ -308,10 +310,19 @@ public class NacosConfigProperties {
 			this.logEnable = logEnable;
 		}
 
+		public boolean isSnapshotEnable() {
+			return snapshotEnable;
+		}
+
+		public void setSnapshotEnable(boolean snapshotEnable) {
+			this.snapshotEnable = snapshotEnable;
+		}
+
 		@Override
 		public String toString() {
 			final StringBuffer sb = new StringBuffer("Bootstrap{");
 			sb.append("enable=").append(enable);
+			sb.append(", snapshotEnable=").append(snapshotEnable);
 			sb.append(", logEnable=").append(logEnable);
 			sb.append('}');
 			return sb.toString();


### PR DESCRIPTION
解决 #294 的问题，此开关默认为开启状态，只有配置为false时才会起作用。目前只能在启动项目服务的时候显示调用SnapShotSwitch.setIsSnapShot(false);才会不在本地保存快照，增加这个配置会更友好一些。
此配置只需要在配置管理里面起作用，因为有些配置为敏感信息，不可以在客户端保存，而自动发现可以不用此开关默认打开即可