### PR TITLE
encode配置加载

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/properties/NacosConfigProperties.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/properties/NacosConfigProperties.java
@@ -365,6 +365,8 @@ public class NacosConfigProperties {
 
 		private String password;
 
+		private String encode;
+
 		public String getUsername() {
 			return username;
 		}
@@ -501,6 +503,14 @@ public class NacosConfigProperties {
 			this.enableRemoteSyncConfig = enableRemoteSyncConfig;
 		}
 
+		public String getEncode() {
+			return encode;
+		}
+
+		public void setEncode(String encode) {
+			this.encode = encode;
+		}
+
 		@Override
 		public String toString() {
 			final StringBuffer sb = new StringBuffer("Config{");
@@ -514,6 +524,7 @@ public class NacosConfigProperties {
 			sb.append(", dataIds='").append(dataIds).append('\'');
 			sb.append(", group='").append(group).append('\'');
 			sb.append(", type=").append(type);
+			sb.append(", encode='").append(encode).append('\'');
 			sb.append(", maxRetry='").append(maxRetry).append('\'');
 			sb.append(", configLongPollTimeout='").append(configLongPollTimeout)
 					.append('\'');

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoader.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosConfigLoader.java
@@ -92,7 +92,8 @@ public class NacosConfigLoader {
 				nacosConfigProperties.getMaxRetry(),
 				nacosConfigProperties.getContextPath(),
 				nacosConfigProperties.isEnableRemoteSyncConfig(),
-				nacosConfigProperties.getUsername(), nacosConfigProperties.getPassword());
+				nacosConfigProperties.getUsername(), nacosConfigProperties.getPassword(),
+				nacosConfigProperties.getEncode());
 	}
 
 	private Properties buildSubNacosProperties(ConfigurableEnvironment environment, Properties globalProperties,
@@ -102,7 +103,7 @@ public class NacosConfigLoader {
 				config.getSecretKey(), config.getAccessKey(), config.getRamRoleName(),
 				config.getConfigLongPollTimeout(), config.getConfigRetryTime(),
 				config.getMaxRetry(),null, config.isEnableRemoteSyncConfig(),
-				config.getUsername(), config.getPassword());
+				config.getUsername(), config.getPassword(), config.getEncode());
 		NacosPropertiesBuilder.merge(sub, globalProperties);
 		return sub;
 	}

--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosPropertiesBuilder.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/util/NacosPropertiesBuilder.java
@@ -16,6 +16,8 @@
  */
 package com.alibaba.boot.nacos.config.util;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Properties;
 
@@ -31,11 +33,20 @@ import org.springframework.util.CollectionUtils;
  */
 public class NacosPropertiesBuilder {
 
+	public static String unifiedCodingName(String encode) {
+		Charset charset = StandardCharsets.UTF_8;
+		if(encode == null){
+			return charset.name();
+		}
+		charset = Charset.forName(encode);
+		return charset.name();
+	}
+
 	public static Properties buildNacosProperties(Environment environment,
 			String serverAddr, String namespaceId, String endpoint, String secretKey,
 			String accessKey, String ramRoleName, String configLongPollTimeout,
 			String configRetryTimeout, String maxRetry,String contextPath, boolean enableRemoteSyncConfig,
-			String username, String password) {
+			String username, String password, String encode) {
 		Properties properties = new Properties();
 		processPropertiesData(properties,environment,serverAddr,PropertyKeyConst.SERVER_ADDR);
 		processPropertiesData(properties,environment,namespaceId,PropertyKeyConst.NAMESPACE);
@@ -49,12 +60,13 @@ public class NacosPropertiesBuilder {
 		processPropertiesData(properties,environment,maxRetry,PropertyKeyConst.MAX_RETRY);
 		processPropertiesData(properties,environment,username,PropertyKeyConst.USERNAME);
 		processPropertiesData(properties,environment,password,PropertyKeyConst.PASSWORD);
-		
+		processPropertiesData(properties,environment,unifiedCodingName(encode),PropertyKeyConst.ENCODE);
+
 		properties.put(PropertyKeyConst.ENABLE_REMOTE_SYNC_CONFIG,
 				String.valueOf(enableRemoteSyncConfig));
 		return properties;
 	}
-	
+
 	private static void processPropertiesData(Properties properties,Environment environment,String keyword,String key) {
 		if (StringUtils.isNotBlank(keyword)) {
 			properties.put(key ,environment.resolvePlaceholders(keyword));

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosConfigLoaderTest.java
@@ -83,6 +83,7 @@ public class NacosConfigLoaderTest {
         nacosConfigProperties.setGroup("group01");
         nacosConfigProperties.setAutoRefresh(true);
         nacosConfigProperties.setEndpoint("localhost");
+        nacosConfigProperties.setEncode("utf8");
         globalProperties = new Properties();
         globalProperties.setProperty("maxRetry","3");
         globalProperties.setProperty("content","key=01");
@@ -104,7 +105,7 @@ public class NacosConfigLoaderTest {
         Properties properties = nacosConfigLoader.buildGlobalNacosProperties(environment, nacosConfigProperties);
         LOGGER.info("buildGlobalNacosProperties properties : {}", properties);
         Assert.assertNotNull(properties);
-        Assert.assertEquals(properties.size(), 6);
+        Assert.assertEquals(properties.size(), 7);
     }
     
     @Test

--- a/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosPropertiesBuilderTest.java
+++ b/nacos-config-spring-boot-autoconfigure/src/test/java/com/alibaba/boot/nacos/util/NacosPropertiesBuilderTest.java
@@ -55,10 +55,11 @@ public class NacosPropertiesBuilderTest {
         String enableRemoteSyncConfig = "enableRemoteSyncConfig";
         String username = "nacos";
         String password = "password";
+        String encode = "utf8";
         Properties properties = NacosPropertiesBuilder.buildNacosProperties(environment, serverAddr, namespaceId, secretKey,
                 "ak", ramRoleName, configLongPollTimeout, configRetryTimeout, maxRetry, null,enableRemoteSyncConfig, true,
-                username, password);
-        Assert.assertEquals(properties.size(), 12);
+                username, password, encode);
+        Assert.assertEquals(properties.size(), 13);
         Assert.assertEquals(properties.get("serverAddr"), "localhost");
     }
 


### PR DESCRIPTION
## bug描述：
之前配置文件中的encode属性不会被加载到GlobalNacosProperties，导致当加载全局配置时创建的ConfigService的cacheKey不包含encode属性
`CacheableEventPublishingNacosServiceFactory`
```java
        public ConfigService run(Properties properties, ConfigService service) throws NacosException {
           // 当通过全局配置配置创建时，这里的cacheKey不包含encode
            String cacheKey = NacosUtils.identify(properties);
            ConfigService configService = (ConfigService)CacheableEventPublishingNacosServiceFactory.this.configServicesCache.get(cacheKey);
            if (configService == null) {
                if (service == null) {
                    service = NacosFactory.createConfigService(properties);
                }

                configService = new EventPublishingConfigService(service, properties, CacheableEventPublishingNacosServiceFactory.getSingleton().context, CacheableEventPublishingNacosServiceFactory.getSingleton().nacosConfigListenerExecutor);
                CacheableEventPublishingNacosServiceFactory.this.configServicesCache.put(cacheKey, configService);
            }

            return (ConfigService)configService;
        }
```
但是注解`@NacosConfigurationProperties`加载的默认配置，又会默认包含encode`UTF-8`，所以这导致同一个服务的cacheKey不一致会创建两次ConfigService 

## 修改内容
1. 为`SubNacosProperties`增加`encode`属性属性
2. 创建`GlobalNacosProperties`和`SubNacosProperties`时会使用配置文件的里的encode