### PR TITLE
[ISSUE #12478] fix global properties error

### DIFF
--- a/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
+++ b/nacos-config-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/nacos/config/autoconfigure/NacosConfigApplicationContextInitializer.java
@@ -95,13 +95,6 @@ public class NacosConfigApplicationContextInitializer
 				configLoader.addListenerIfAutoRefreshed();
 			}
 		}
-
-		final ConfigurableListableBeanFactory factory = context.getBeanFactory();
-		if (!factory
-				.containsSingleton(NacosBeanUtils.GLOBAL_NACOS_PROPERTIES_BEAN_NAME)) {
-			factory.registerSingleton(NacosBeanUtils.GLOBAL_NACOS_PROPERTIES_BEAN_NAME,
-					configLoader.getGlobalProperties());
-		}
 	}
 
 	private boolean enable() {


### PR DESCRIPTION
Resolve conflicts between configuration items in the configuration center and registration center
for #https://github.com/alibaba/nacos/issues/12478

Validation methods:
1. After modification, the registration center and configuration center are configured independently.
2. After modification, the system starts up normally and reads configurations correctly.
